### PR TITLE
Enable OSX as a platform

### DIFF
--- a/OSX_README.md
+++ b/OSX_README.md
@@ -1,0 +1,12 @@
+# Running Armoured Commander II on OSX
+
+To run on OSX use a virtual environment (e.g. pipenv) with a Python >= 3.6.6 and
+install the following libraries:
+
+tcod
+pysdl2
+
+Then run `python armcom2.py`
+
+If the font size is too large then change the 'display_font_size in
+data/armcom2.cfg 

--- a/armcom2.py
+++ b/armcom2.py
@@ -36,8 +36,10 @@
 
 ##### Libraries #####
 import os, sys						# OS-related stuff
-if os.name == 'posix':					# if linux - load system libtcodpy
-	import libtcodpy_local as libtcod		
+if sys.platform == 'darwin':
+	import tcod as libtcod
+elif os.name == 'posix':					# if linux - load system libtcodpy
+	import libtcodpy_local as libtcod
 else:
 	import libtcodpy as libtcod			# The Doryen Library
 	os.environ['PYSDL2_DLL_PATH'] = os.getcwd() + '/lib'.replace('/', os.sep)	# set sdl2 dll path
@@ -65,7 +67,9 @@ DATAPATH = 'data/'.replace('/', os.sep)			# path to data files
 SOUNDPATH = 'sounds/'.replace('/', os.sep)		# path to sound samples
 CAMPAIGNPATH = 'campaigns/'.replace('/', os.sep)	# path to campaign files
 
-if os.name == 'posix':					# linux (and OS X?) has to use SDL for some reason
+if sys.platform == 'darwin':
+	RENDERER = libtcod.RENDERER_SDL2
+elif os.name == 'posix':					# linux (and OS X?) has to use SDL for some reason
 	RENDERER = libtcod.RENDERER_SDL
 else:
 	RENDERER = libtcod.RENDERER_GLSL

--- a/xp_loader.py
+++ b/xp_loader.py
@@ -1,6 +1,10 @@
 # Changed slightly to be compatible with Python 3
 
-import libtcodpy as libtcod
+from sys import platform
+if platform == 'darwin':
+	import tcod as libtcod
+else:
+	import libtcodpy as libtcod
 import binascii
 
 ##################################


### PR DESCRIPTION
This pull request enables OSX support.

The main change is to not use the local copy of libtcod, as this does not have the dynamic libraries required for OSX, but to instead prefer a system local installation, i.e. via Pip. This has been changed in both the main game and in the xp_loader.

An OSX_README.md has been added to describe how to run the game under OSX. 

Finally, SDL2 is set as the renderer on OSX.