### PR TITLE
Fix issues when changing font on options screen

### DIFF
--- a/armcom2.py
+++ b/armcom2.py
@@ -11990,12 +11990,12 @@ def ChangeGameSettings(key_char, main_menu=False):
 		libtcod.console_delete(0)
 		if config.getboolean('ArmCom2', 'large_display_font'):
 			config['ArmCom2']['large_display_font'] = 'false'
-			fontname = 'c64_8x8.png'
+			fontname = 'c64_8x8_ext.png'
 		else:
 			config['ArmCom2']['large_display_font'] = 'true'
-			fontname = 'c64_16x16.png'
+			fontname = 'c64_16x16_ext.png'
 		libtcod.console_set_custom_font(DATAPATH+fontname,
-			libtcod.FONT_LAYOUT_ASCII_INROW, 0, 0)
+			libtcod.FONT_LAYOUT_ASCII_INROW, 16, 18)
 		libtcod.console_init_root(WINDOW_WIDTH, WINDOW_HEIGHT,
 			NAME + ' - ' + VERSION, fullscreen = False,
 			renderer = RENDERER)


### PR DESCRIPTION
Fixes a crash due to missing files and also ensures custom font is setup
correctly.

It looks like the file paths for the fonts weren't updated in the options screen code and I was getting an issue where changing the font size would cause corruption. Setting the column and row sizes explicitly fixes that.